### PR TITLE
allow meteor to be run from subdirectories

### DIFF
--- a/package.js
+++ b/package.js
@@ -53,7 +53,32 @@ Package.on_use(function(api) {
   api.export('__init_fast_render', ['client']);
 });
 
+function isAppDir(filepath) {
+  try {
+    return fs.statSync(path.join(filepath, '.meteor', 'packages')).isFile();
+  } catch (e) {
+    return false;
+  }
+}
+
+function meteorRoot() {
+  var testDir = process.cwd();
+
+  while (testDir) {
+    if (isAppDir(testDir))
+      break;
+
+    var newDir = path.dirname(testDir);
+    if (newDir === testDir)
+      return null;
+
+    testDir = newDir;
+  }
+
+  return testDir;
+}
+
 function isIronRouterExists() {
-  var meteorPackages = fs.readFileSync(path.resolve('.meteor/packages'), 'utf8');
+  var meteorPackages = fs.readFileSync(path.join(meteorRoot(), '.meteor', 'packages'), 'utf8');
   return !!meteorPackages.match(/iron-router/);
 }


### PR DESCRIPTION
Meteor can be run from subdirectories of the root project, as well as the root of the project.  When run in subdirectories, fast-render was not compiling successfully as it was attempting to find `.meteor/packages` somewhere where it doesn't exist.

This is a rough replication of Meteor's app directory identification code, and should successfully determine the correct location to look for the iron-router package, even when run in a subdirectory.
