### PR TITLE
Add `.npm` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .tmp-qa
 .build*
+.npm


### PR DESCRIPTION
Avoid `dirty` message when using the package as a git submodule (ie, without `mrt`)
