### PR TITLE
Set `window.Cookies` to undefined

### DIFF
--- a/lib/vendor/cookies.js
+++ b/lib/vendor/cookies.js
@@ -144,4 +144,5 @@
 
 //clearning form the window
 Cookies = window.Cookies;
-delete window.Cookies;
+// IE 8 doesn't support delete on window properties
+window.Cookies = undefined;


### PR DESCRIPTION
As mentioned in #46, properties of the `window` object can't be deleted in IE8, and therefore should be set to undefined.
