### PR TITLE
fixes iron-router errors while using tinytest

### DIFF
--- a/package.js
+++ b/package.js
@@ -17,7 +17,6 @@ Package.on_use(function(api) {
   //   https://github.com/meteor/meteor/issues/1358
   // The 'weak' flag doesn't support non-core (ie. atmosphere) packages yet.
   if(isMeteorAppWithIronRouterDependency() || isPackageWithIronRouterDependency()) {
-
     // the app or package uses iron-router -> so we can use it too!
     api.use(['iron-router'], ['client', 'server']);
   }
@@ -107,11 +106,9 @@ function isMeteorAppWithIronRouterDependency() {
 }
 
 function isPackageWithIronRouterDependency() {
-
   var processDirectory = process.cwd();
-
+  
   if(isPackageDirectory(processDirectory)) {
-
     var packageFile = fs.readFileSync(path.join(processDirectory, 'package.js'), 'utf8');
     return !!packageFile.match(/iron-router/);
   }


### PR DESCRIPTION
The changes add support for standalone packages that are not contained within a Meteor application.

It also changes the iron-router dependency from `weak` to normal because it currently doesn't work anyway (with meteorite packages) and caused additional problems. Since we check manually if the container Meteor app or package has iron-router as dependency we don't need  weak references (iron-router will be there).

Currently the manual checks are pretty simple – it just searches for the string `iron-router` within the `.meteor/packages` and `package.js` files. But I guess it will be sufficient for the moment ;-)
