### PR TITLE
Fixes #65 – Wrong reference to Router instance of iron:router package 

### DIFF
--- a/lib/server/iron_router_support.js
+++ b/lib/server/iron_router_support.js
@@ -1,7 +1,7 @@
 if(!Package['iron:router']) return;
 
 var RouteController = Package['iron:router'].RouteController;
-var ServerRouter = Package['iron:router'].ServerRouter;
+var Router = Package['iron:router'].Router;
 
 var currentSubscriptions = [];
 Meteor.subscribe = function(subscription) {


### PR DESCRIPTION
This was a pretty simple fix – it was just referring to the wrong export `ServerRouter` which doesn't even exist anymore in the iron:router package. This PR changes it to `Router` again which fixed the ReferenceError problem for me ;-)
