### PR TITLE
Fallback to RouteController for settings

### DIFF
--- a/lib/server/iron_router_support.js
+++ b/lib/server/iron_router_support.js
@@ -127,12 +127,15 @@ function getPath(route) {
   }
 }
 
-function getController (route) {
+function getController(route) {
   if(route.findControllerConstructor) {
     // for IR 1.0
     return route.findControllerConstructor();
   } else if(route.findController) {
     // for IR 0.9
     return route.findController();
+  } else {
+    // unsupported version of IR
+    return null;
   }
 }


### PR DESCRIPTION
(While fixing https://github.com/meteorhacks/fast-render/issues/84, I discovered a similar bug in handleRoute)

processRoutes() didn't look up the RouterController for a given route
correctly, and handleRoute() didn't consider the fact that if a route
doesn't declare a waitOn or a subscriptions, iron-router will use its
RouteController's waitOr or subscriptions
