### PR TITLE
Expose publish context on FastRender export

### DIFF
--- a/lib/server/publish_context.js
+++ b/lib/server/publish_context.js
@@ -83,3 +83,5 @@ PublishContext.prototype.ready = function() {
 
 PublishContext.prototype.error = function() {};
 PublishContext.prototype.stop = function() {};
+
+FastRender._PublishContext = PublishContext;

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ var path = Npm.require('path');
 
 Package.describe({
   "summary": "Render your app before the DDP connection even comes alive - magic?",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "git": "https://github.com/meteorhacks/fast-render",
   "name": "meteorhacks:fast-render"
 });


### PR DESCRIPTION
We ran into an issue using [this SSR router for react](https://github.com/thereactivestack/meteor-react-router-ssr) when trying to publish data from our [rest2ddp](https://github.com/NewSpring/rest2ddp) package. By exposing the publish context we were able to use remote data in connection with fast render! 