### PR TITLE
Allow change/remove of other pubs docs to fix #142

### DIFF
--- a/lib/server/context.js
+++ b/lib/server/context.js
@@ -3,6 +3,7 @@ var Future = Npm.require('fibers/future');
 
 Context = function Context(loginToken, otherParams) {
   this._collectionData = {};
+  this._collectionPubMaps = {};
   this._subscriptions = {};
   this._loginToken = loginToken;
   
@@ -142,6 +143,38 @@ Context.prototype.getData = function() {
     subscriptions: this._subscriptions,
     loginToken: this._loginToken
   };
+};
+
+Context.prototype._added = function(collectionName, id, pubId) {
+  if (!this._collectionPubMaps[collectionName])
+    this._collectionPubMaps[collectionName] = {};
+  var pubMap = this._collectionPubMaps[collectionName];
+  if (!pubMap[id])
+    pubMap[id] = { publisherCount: 0, isPublishedBy: {} };
+  var pubMapForId = pubMap[id];
+  var isPublishedBy = pubMapForId.isPublishedBy;
+  if (!isPublishedBy[pubId]) {
+    isPublishedBy[pubId] = true;
+    pubMapForId.publisherCount++;
+  }
+};
+
+Context.prototype._removed = function(collectionName, id, pubId) {
+  if (!this._collectionPubMaps[collectionName] ||
+      !this._collectionPubMaps[collectionName][id])
+    return;
+  var pubMapForId = this._collectionPubMaps[collectionName][id];
+  if (pubMapForId.isPublishedBy[pubId]) {
+    delete pubMapForId.isPublishedBy[pubId];
+    pubMapForId.publisherCount--;    
+  }
+};
+
+Context.prototype._docIsPublished = function(collectionName, id) {
+  if (!this._collectionPubMaps[collectionName] ||
+      !this._collectionPubMaps[collectionName][id])
+    return false;
+  return (this._collectionPubMaps[collectionName][id].publisherCount !== 0);
 };
 
 FastRender._Context = Context;

--- a/lib/server/publish_context.js
+++ b/lib/server/publish_context.js
@@ -41,6 +41,16 @@ PublishContext.prototype._ensureCollection = function(collection) {
   }
 };
 
+PublishContext.prototype._existsInAnotherView = function(collection, id) {
+  var otherViews = this._context._collectionData[collection] || [];
+  return otherViews.some(function(view) {
+    view = view || [];
+    return view.some(function(doc) {
+      return doc._id === id;
+    });
+  });  
+};
+
 PublishContext.prototype.added = function(collection, id, fields) {
   this._ensureCollection(collection);
   var doc = _.clone(fields);
@@ -49,23 +59,50 @@ PublishContext.prototype.added = function(collection, id, fields) {
 };
 
 PublishContext.prototype.changed = function(collection, id, fields) {
+  this._ensureCollection(collection);
   var collectionData = this._collectionData;
-
+  var found = false;
   collectionData[collection] = collectionData[collection].map(function(doc) {
     if (doc._id === id) {
+      found = true;
       return _.extend(doc, fields);
     }
 
     return doc;
   });
+  // If we found the doc, then we've changed it so we're done
+  if (found)
+    return;
+  // Otherwise, see if it exists in another view within this context
+  if (this._existsInAnotherView(collection, id)) {
+    // Found it, so we can just add it to our view.
+    this.added(collection, id, fields);
+  } else {
+    // We didn't find it, so attempting to change it is an error
+    throw new Error("Could not find element with id " + id + " to change");      
+  }
 };
 
 PublishContext.prototype.removed = function(collection, id) {
+  this._ensureCollection(collection);
   var collectionData = this._collectionData;
-
+  var found = false;
   collectionData[collection] = collectionData[collection].filter(function(doc) {
-    return doc._id !== id;
+    if (doc._id === id) {
+      found = true;
+      return false;
+    } else {
+      return true;
+    }
   });
+  // If we found the doc, then we've removed it so we're done
+  if (found)
+    return;
+  // Otherwise, throw an error if it doesn't exists in another view within this
+  // context.
+  if (!this._existsInAnotherView(collection, id)) {
+    throw new Error("Removed nonexistent document " + id);     
+  }
 };
 
 PublishContext.prototype.onStop = function(cb) {

--- a/lib/server/publish_context.js
+++ b/lib/server/publish_context.js
@@ -1,6 +1,7 @@
 PublishContext = function PublishContext(context, subscription) {
   this.userId = context.userId;
   this.unblock = function() {};
+  this._pubId = Random.id();
   this._subscription = subscription;
   this._context = context;
   this._collectionData = {};
@@ -41,21 +42,12 @@ PublishContext.prototype._ensureCollection = function(collection) {
   }
 };
 
-PublishContext.prototype._existsInAnotherView = function(collection, id) {
-  var otherViews = this._context._collectionData[collection] || [];
-  return otherViews.some(function(view) {
-    view = view || [];
-    return view.some(function(doc) {
-      return doc._id === id;
-    });
-  });  
-};
-
 PublishContext.prototype.added = function(collection, id, fields) {
   this._ensureCollection(collection);
   var doc = _.clone(fields);
   doc._id = id;
   this._collectionData[collection].push(doc);
+  this._context._added(collection, id, this._pubId);
 };
 
 PublishContext.prototype.changed = function(collection, id, fields) {
@@ -74,7 +66,7 @@ PublishContext.prototype.changed = function(collection, id, fields) {
   if (found)
     return;
   // Otherwise, see if it exists in another view within this context
-  if (this._existsInAnotherView(collection, id)) {
+  if (this._context._docIsPublished(collection, id)) {
     // Found it, so we can just add it to our view.
     this.added(collection, id, fields);
   } else {
@@ -95,14 +87,12 @@ PublishContext.prototype.removed = function(collection, id) {
       return true;
     }
   });
-  // If we found the doc, then we've removed it so we're done
-  if (found)
-    return;
-  // Otherwise, throw an error if it doesn't exists in another view within this
-  // context.
-  if (!this._existsInAnotherView(collection, id)) {
+  // If we didn't find (and remove) it, throw an error if it doesn't exists in
+  // another view within this context.
+  if (!found && !this._context._docIsPublished(collection, id)) {
     throw new Error("Removed nonexistent document " + id);     
   }
+  this._context._removed(collection, id, this._pubId);  
 };
 
 PublishContext.prototype.onStop = function(cb) {


### PR DESCRIPTION
Change PublishContext.changed() and PublishContext.removed() to ensure that the
collection exists, and if there isn't a doc with the requested id in the current
publish context, to look for one that was published in another publish context.
If one is found, changed() adds the doc to the current publish context and
removed() does nothing. If there isn't, both throw the same errors that would be
thrown by the merge box.