### PR TITLE
Buffered livedata fix

### DIFF
--- a/lib/client/fast_render.js
+++ b/lib/client/fast_render.js
@@ -56,6 +56,8 @@ FastRender.init = function(payload) {
     });
   }
 
+  var connection = Meteor.connection;
+
   _.each(allData, function(collData, collName) {
     _.each(collData, function(item, id) {
       var id = IDTools.idStringify(item._id);
@@ -69,9 +71,12 @@ FastRender.init = function(payload) {
         frGen: true
       };
 
-      FastRender.injectDdpMessage(Meteor.connection, ddpMessage);
+      FastRender.injectDdpMessage(connection, ddpMessage);
     });
   });
+
+  // If the connection supports buffered DDP writes, then flush now.
+  if (connection._flushBufferedWrites) connection._flushBufferedWrites();
 
   // let Meteor know, user login process has been completed
   if(typeof Accounts != 'undefined') {

--- a/lib/client/fast_render.js
+++ b/lib/client/fast_render.js
@@ -18,10 +18,17 @@ if(FastRender._disable) {
 //  This is the cure
 FastRender.injectDdpMessage = function(conn, message) {
   FastRender["debugger"].log('injecting ddp message:', message);
-  var originalWait = conn._waitingForQuiescence;
-  conn._waitingForQuiescence = function() {return false};
-  conn._livedata_data(message);
-  conn._waitingForQuiescence = originalWait;
+  if (conn._bufferedWrites) {
+    // New with meteor/meteor#5680
+    // If the livedata connection supports buffered writes,
+    // we don't need check if we're in delay before injecting.
+    conn._livedata_data(message);
+  } else {
+    var originalWait = conn._waitingForQuiescence;
+    conn._waitingForQuiescence = function() {return false};
+    conn._livedata_data(message);
+    conn._waitingForQuiescence = originalWait;
+  }
 };
 
 FastRender.init = function(payload) {

--- a/tests/client/ddp_update.js
+++ b/tests/client/ddp_update.js
@@ -1,4 +1,4 @@
-Tinytest.add('DDPUpdate - convert added to changed', function(test) {
+Tinytest.addAsync('DDPUpdate - convert added to changed', function(test, done) {
   var collName = Random.id();
   var coll = new Mongo.Collection(collName);
 
@@ -9,19 +9,25 @@ Tinytest.add('DDPUpdate - convert added to changed', function(test) {
     fields: {name: "arunoda"}
   });
 
-  test.equal(coll.findOne('one'), {_id: 'one', name: 'arunoda'});
+  Meteor.setTimeout(function () {
+    test.equal(coll.findOne('one'), {_id: 'one', name: 'arunoda'});
 
-  Meteor.connection._livedata_data({
-    msg: 'added',
-    collection: collName,
-    id: 'one',
-    fields: {name: "kuma", age: 20}
-  });
+    Meteor.connection._livedata_data({
+      msg: 'added',
+      collection: collName,
+      id: 'one',
+      fields: {name: "kuma", age: 20}
+    });
 
-  test.equal(coll.findOne('one'), {_id: 'one', name: 'kuma', age: 20});
+    Meteor.setTimeout(function () {
+      test.equal(coll.findOne('one'), {_id: 'one', name: 'kuma', age: 20});
+      done();
+    }, bufferedWritesInterval);
+
+  }, bufferedWritesInterval);
 });
 
-Tinytest.add('DDPUpdate - create collection later on', function(test) {
+Tinytest.addAsync('DDPUpdate - create collection later on', function(test, done) {
   var collName = Random.id();
 
   Meteor.connection._livedata_data({
@@ -39,7 +45,10 @@ Tinytest.add('DDPUpdate - create collection later on', function(test) {
   });
 
   var coll = new Mongo.Collection(collName);
-  test.equal(coll.find().fetch().length, 2);
+  Meteor.setTimeout(function () {
+    test.equal(coll.find().fetch().length, 2);
+    done();
+  }, bufferedWritesInterval);
 });
 
 Tinytest.add('DDPUpdate - delete subscriptions', function(test) {

--- a/tests/client/fast_render.js
+++ b/tests/client/fast_render.js
@@ -51,7 +51,7 @@ Tinytest.addAsync('FastRender - init - ObjectId support', function(test, done) {
   });
 });
 
-Tinytest.add('FastRender - init - merge docs', function(test) {
+Tinytest.addAsync('FastRender - init - merge docs', function(test, done) {
   var collName = Random.id();
   var payload = {
     subscriptions: {posts: true},
@@ -69,16 +69,19 @@ Tinytest.add('FastRender - init - merge docs', function(test) {
   FastRender.init(payload);
 
   var coll = new Mongo.Collection(collName);
-  test.equal(coll.findOne('one'), {
-    _id: "one",
-    name: "arunoda",
-    age: 30,
-    city: "colombo",
-    plan: "pro"
-  });
+  Meteor.setTimeout(function () {
+    test.equal(coll.findOne('one'), {
+      _id: "one",
+      name: "arunoda",
+      age: 30,
+      city: "colombo",
+      plan: "pro"
+    });
+    done();
+  }, bufferedWritesInterval);
 });
 
-Tinytest.add('FastRender - init - merge docs deep', function(test) {
+Tinytest.addAsync('FastRender - init - merge docs deep', function(test, done) {
   var collName = Random.id();
   var payload = {
     subscriptions: {posts: true},
@@ -95,18 +98,21 @@ Tinytest.add('FastRender - init - merge docs deep', function(test) {
   FastRender.init(payload);
 
   var coll = new Mongo.Collection(collName);
-  test.equal(coll.findOne('one'), {
-    _id: "one",
-    name: "arunoda",
-    profile: {
+  Meteor.setTimeout(function () {
+    test.equal(coll.findOne('one'), {
+      _id: "one",
       name: "arunoda",
-      email: "arunoda@arunoda.com"
-    }
-  });
+      profile: {
+        name: "arunoda",
+        email: "arunoda@arunoda.com"
+      }
+    });
+    done();
+  }, bufferedWritesInterval);
 });
 
 
-Tinytest.add('FastRender - init - ejon data', function(test) {
+Tinytest.addAsync('FastRender - init - ejon data', function(test, done) {
   var collName = Random.id();
   var payload = {
     subscriptions: {posts: true},
@@ -123,8 +129,11 @@ Tinytest.add('FastRender - init - ejon data', function(test) {
   FastRender.init(payload);
 
   var coll = new Mongo.Collection(collName);
-  var doc = coll.findOne("one");
-  test.equal(doc.date.getTime(), date.getTime());
+  Meteor.setTimeout(function () {
+    var doc = coll.findOne("one");
+    test.equal(doc.date.getTime(), date.getTime());
+    done();
+  }, bufferedWritesInterval);
 });
 
 WithNewInjectDdpMessage = function(newCallback, runCode) {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,3 +1,5 @@
+bufferedWritesInterval = 5;
+
 Tinytest.add('AddedToChanged - new fields', function(test) {
   var localCopy = {aa: 10};
   var added = {fields: {aa: 20, bb: 20}, msg: 'added'};


### PR DESCRIPTION
Since meteor/meteor#5680 provides (awesome) support for buffered DDP, two (what seem to be) false-positive issues popped up in `fast-render`.  Nothing seemed *actually* wrong unless you were trying to do things mid-CPU tick (like tests or error checking).  Both of these were found during accidental release of that PR in Meteor 1.3.2.1/2.  The PR will be back in Meteor 1.3.3 and this should hopefully address the problems.

1. `flow-router` started throwing a false-positive `You can't use reactive data sources like Session inside the '.subscriptions' method` error (despite the lack of subscriptions) because of the lack of flushing on the same tick in `FastRender.init`.  Calling the connection's `_flushBufferedWrites` (if it exists), fixed this issue with no changes necessary to `flow-router`.  The (incorrectly) thrown error was affecting subscriptions ability to become `ready` because the `Tracker`.

2. `fast-render` package tests started failing because livedata updates were not happening in the same tick as the test that was checking them.  I changed the tests that do this to use `Tinytest.addAsync` and wait until the default `_bufferedWritesInterval` milliseconds have passed.  This value is hardcoded to *5* in `livedata`, so I used that here too.

Fixes #166