### PR TITLE
Fix for Meteor 1.3 / 1.4

### DIFF
--- a/lib/client/fast_render.js
+++ b/lib/client/fast_render.js
@@ -18,17 +18,13 @@ if(FastRender._disable) {
 //  This is the cure
 FastRender.injectDdpMessage = function(conn, message) {
   FastRender["debugger"].log('injecting ddp message:', message);
-  if (conn._bufferedWrites) {
-    // New with meteor/meteor#5680
-    // If the livedata connection supports buffered writes,
-    // we don't need check if we're in delay before injecting.
-    conn._livedata_data(message);
-  } else {
+
+
     var originalWait = conn._waitingForQuiescence;
     conn._waitingForQuiescence = function() {return false};
     conn._livedata_data(message);
     conn._waitingForQuiescence = originalWait;
-  }
+
 };
 
 FastRender.init = function(payload) {

--- a/lib/client/fast_render.js
+++ b/lib/client/fast_render.js
@@ -19,6 +19,8 @@ if(FastRender._disable) {
 FastRender.injectDdpMessage = function(conn, message) {
   FastRender["debugger"].log('injecting ddp message:', message);
 
+// Removed check for conn._bufferedWrites due to https://github.com/kadirahq/fast-render/pull/167/files#r74189260 
+// and https://github.com/kadirahq/fast-render/issues/176
 
     var originalWait = conn._waitingForQuiescence;
     conn._waitingForQuiescence = function() {return false};


### PR DESCRIPTION
I've just removed the check for <code>conn_.bufferedWrites</code> like @tmeasday mentioned [here](https://github.com/kadirahq/fast-render/pull/167/files). On my 1.4 Meteor application, Fast Render seems to work again without problems.