### PR TITLE
Fast-Render re-write feature tries to re-write `added` messages of non existing document

### DIFF
--- a/lib/client/ddp_update.js
+++ b/lib/client/ddp_update.js
@@ -27,7 +27,7 @@ Meteor.connection._livedata_data = function(msg) {
       var localCollection = this._mongo_livedata_collections[msg.collection];
       var pendingStoreUpdates = this._updatesForUnknownStores[msg.collection];
       if(localCollection) {
-        var existingDoc = this.__getLocalDocByMsg(msg, {bufferedMessagesLookup: true});
+        var existingDoc = getLocalDocByMsg.call(this, msg, {bufferedMessagesLookup: true});
         if(existingDoc) {
           FastRender["debugger"].log('re writing DDP for:', msg);
           AddedToChanged(existingDoc, msg);
@@ -118,7 +118,7 @@ Meteor.connection._send = function(msg) {
   return originalSend.call(this, msg);
 };
 
-Meteor.connection.__getLocalDocByMsg = function (msg, options) {
+function getLocalDocByMsg (msg, options) {
   var self = this;
 
   var collection = self._mongo_livedata_collections[msg.collection];
@@ -136,16 +136,10 @@ Meteor.connection.__getLocalDocByMsg = function (msg, options) {
     if (bufferedMessages) {
       for (var i = bufferedMessages.length - 1; i >= 0; i--) {
         var message = bufferedMessages[i];
-        if (message.id == msg.id) {
-          // Skip further lookup if earlier message tries to add document
-          if (message.msg == 'added') {
-            return doc;
-          }
-          // Consider document as removed if earlier message removes the document
-          // We should skip rewrite phase in this case to avoid updating of non existing doc.
-          if (message.msg == 'removed') {
-            return null;
-          }
+        // Consider document as removed if earlier message removes the document
+        // We should skip rewrite phase in this case to avoid updating of non existing doc.
+        if (message.id == msg.id && message.msg == 'removed') {
+          return null;
         }
       }
     }

--- a/lib/client/ddp_update.js
+++ b/lib/client/ddp_update.js
@@ -27,7 +27,7 @@ Meteor.connection._livedata_data = function(msg) {
       var localCollection = this._mongo_livedata_collections[msg.collection];
       var pendingStoreUpdates = this._updatesForUnknownStores[msg.collection];
       if(localCollection) {
-        var existingDoc = localCollection.findOne(id);
+        var existingDoc = this.__getLocalDocByMsg(msg, {bufferedMessagesLookup: true});
         if(existingDoc) {
           FastRender["debugger"].log('re writing DDP for:', msg);
           AddedToChanged(existingDoc, msg);
@@ -116,4 +116,39 @@ Meteor.connection._send = function(msg) {
   }
 
   return originalSend.call(this, msg);
+};
+
+Meteor.connection.__getLocalDocByMsg = function (msg, options) {
+  var self = this;
+
+  var collection = self._mongo_livedata_collections[msg.collection];
+  if (!collection) {
+    return null;
+  }
+
+  var doc = collection.findOne(msg.id);
+  options = typeof options == 'object' ? options : {};
+
+  if (options.bufferedMessagesLookup && doc && msg.msg == 'added') {
+    if (self._waitingForQuiescence()) return doc;
+
+    var bufferedMessages = self._bufferedWrites && self._bufferedWrites[msg.collection];
+    if (bufferedMessages) {
+      for (var i = bufferedMessages.length - 1; i >= 0; i--) {
+        var message = bufferedMessages[i];
+        if (message.id == msg.id) {
+          // Skip further lookup if earlier message tries to add document
+          if (message.msg == 'added') {
+            return doc;
+          }
+          // Consider document as removed if earlier message removes the document
+          // We should skip rewrite phase in this case to avoid updating of non existing doc.
+          if (message.msg == 'removed') {
+            return null;
+          }
+        }
+      }
+    }
+  }
+  return doc;
 };


### PR DESCRIPTION
### Issue:

There is still a case when fast-render re-writes `added` messages of previously removed documents. As result meteor throws the following error:
![fast-render example 2017-02-24 16-38-05](https://cloud.githubusercontent.com/assets/5029609/23307300/aa8024aa-faaf-11e6-94b4-9d3efc14e303.png)

Here is an example app where you could try this out: https://github.com/varenytskyi/fast-render-example/tree/master
or see this [video](http://quick.as/pDD1CRJGv)

Mostly it happens when document is re-added with another cursor in complex publications

---

### Fix:

The fix is pretty simple. Since meteor buffers ddp messages we have to be sure that there is no `removed` message in internal meteor queue before re-writing `added` message of the same document.

There is a branch with patched fast-render in the app I've mentioned above: https://github.com/varenytskyi/fast-render-example/tree/with-patched-fast-render
Here is also a [video](http://quick.as/dBBDflWBX) how patched version works.